### PR TITLE
Add ssh client

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
     chmod +x /usr/local/bin/install-php-extensions; sync; \
 	install-php-extensions ${PHP_EXTENSIONS}; \
 	apt-get update; \
-    apt-get install -y --no-install-recommends git npm gettext unzip pwgen nmap ncat jq; \
+    apt-get install -y --no-install-recommends git openssh-client npm gettext unzip pwgen nmap ncat jq; \
     rm -rf /var/lib/apt/lists/*
 
 # Set primary INI file and PHP memory limit


### PR DESCRIPTION
during running composer install I started getting the following error:
```
  error: cannot run ssh: No such file or directory                                                                                                                                                   
  fatal: unable to fork                                                                                                                                                                              
```

Investigate shown that command `ssh` isn't available. Looks like it happened after https://github.com/drpayyne/docker-php/pull/3

This PR adds ssh client back