### PR TITLE
Add MySQLi extension to fpm image

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 # List of PHP extensions
-ARG PHP_EXTENSIONS="amqp bcmath gd gmp imagick intl msgpack opcache pdo_mysql redis soap sockets xmlrpc xsl zip pcntl"
+ARG PHP_EXTENSIONS="amqp bcmath gd gmp imagick intl msgpack opcache pdo_mysql redis soap sockets xmlrpc xsl zip pcntl mysqli"
 
 # Install PHP extensions and other utilities
 RUN set -eux; \


### PR DESCRIPTION
**As response to https://github.com/drpayyne/warden-multi-arch/pull/34** (check for more info)

There's an error when setting up wordpress-sites (and any other applications using `mysqli` ), as mysqli is not installed in the images. The official warden-images also have mysqli included.

This should close https://github.com/drpayyne/warden-multi-arch/discussions/26 .

Furthermore I've tested this build on an M1-chip, and everything builds succesfully :+1: 